### PR TITLE
Add symlink to main venv executable after mkvenv

### DIFF
--- a/autoswitch_virtualenv.plugin.zsh
+++ b/autoswitch_virtualenv.plugin.zsh
@@ -354,6 +354,15 @@ function mkvenv()
             _maybeworkon "$(_virtual_env_dir "$venv_name")" "virtualenv"
 
             install_requirements
+
+            local tool_name="$(basename $PWD | tr '[:upper:]' '[:lower:]')"
+            local venv_bin="$(_virtual_env_dir "$venv_name")/bin"
+            if [[ -x "${venv_bin}/${tool_name}" ]]; then
+                local link_name="run-${tool_name}"
+                ln -sf "${venv_bin}/${tool_name}" "./${link_name}"
+                printf "${AUTOSWITCH_PURPLE}Symlink ./%s → %s created${NONE}\n" \
+                "$link_name" "${venv_bin}/${tool_name}"
+            fi
         fi
     fi
 }


### PR DESCRIPTION
This adds functionality to mkvenv that detects the main tool executable after installing the virtual environment and creates a symbolic link to it in the root of the project directory.

This allows users to run the tool directly via ./run-<tool> without needing to type the full venv path or modify the PATH environment variable.

A 'run-' prefix is used on the symlink to avoid name collisions with folders or files that may already exist in the project structure.

Note: I prefer this option over changing AUTOSWITCH_PIPINSTALL to FULL.